### PR TITLE
Fix ingredient delete

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -768,14 +768,17 @@ DELETE FROM fermentable where id=597;
                                  .arg(ing->_key);
       q.setForwardOnly(true);
 
-      if ( ! q.exec(deleteFromInRecipe) )
-         throw QString("failed to delete in_recipe.");
-
       // I don't really like this, but I can't think of a better solution. Of
       // all the ingredients, instructions don't have a _children table. Given
       // that it is only one table, I will try the easy way first
       if ( tableName != "instruction" && ! q.exec( deleteFromChildren ) )
          throw QString("failed to delete children.");
+
+      if ( ! q.exec(deleteFromInRecipe) )
+         throw QString("failed to delete in_recipe.");
+
+      if ( ! q.exec(deleteFromInInventory) )
+         throw QString("failed to delete in_inventory.");
 
       if ( ! q.exec( deleteIngredient ) )
          throw QString("failed to delete ingredient.");

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -740,12 +740,6 @@ void Database::removeIngredientFromRecipe( Recipe* rec, BeerXMLElement* ing )
       else
          throw QString("could not locate classInfo for signal on %2").arg(meta->className());
 
-/*
-DELETE FROM fermentable_children WHERE child_id = 597;
-DELETE FROM fermentable_in_recipe WHERE fermentable_id = 597;
-DELETE FROM fermentable_in_inventory WHERE fermentable_id = 597;
-DELETE FROM fermentable where id=597;
-*/
       // We need to do many things -- remove the link in *in_recipe,
       // remove the entry from *_children
       QString deleteFromChildren = QString("DELETE FROM %1 WHERE child_id=%2")


### PR DESCRIPTION
Fixes issue where it is impossible to remove a fermentable from a recipe by changing the sequence that items are removed from the database and also ensuring the copy fermenatble is removed from the ingredient table.