### PR TITLE
Stop Travis infinite build loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 os: linux
 services:
 - docker
+if: tag IS blank
 jobs:
   include:
   - stage: Create draft Github Release


### PR DESCRIPTION
Prevents a new build from kicking off whenever a Release (tag) is made.